### PR TITLE
Clearing a BinaryFile attribute does not trigger a refresh (#32)

### DIFF
--- a/wwwroot/web-components/persistent-object-attribute/attributes/persistent-object-attribute-binary-file/persistent-object-attribute-binary-file.ts
+++ b/wwwroot/web-components/persistent-object-attribute/attributes/persistent-object-attribute-binary-file/persistent-object-attribute-binary-file.ts
@@ -72,7 +72,7 @@ export class PersistentObjectAttributeBinaryFile extends PersistentObjectAttribu
             this.attribute.input.value = null;
 
         if(this.attribute?.triggersRefresh)
-            await this.attribute?._triggerAttributeRefresh(true);
+            await this.attribute._triggerAttributeRefresh(true);
     }
 
     private _computeCanClear(value: string, readOnly: boolean): boolean {

--- a/wwwroot/web-components/persistent-object-attribute/attributes/persistent-object-attribute-binary-file/persistent-object-attribute-binary-file.ts
+++ b/wwwroot/web-components/persistent-object-attribute/attributes/persistent-object-attribute-binary-file/persistent-object-attribute-binary-file.ts
@@ -65,11 +65,14 @@ export class PersistentObjectAttributeBinaryFile extends PersistentObjectAttribu
         this.appendChild(attribute.input);
     }
 
-    private _clear() {
+    private async _clear() {
         this.value = null;
         
         if (this.attribute?.input?.files?.length)
             this.attribute.input.value = null;
+
+        if(this.attribute?.triggersRefresh)
+            await this.attribute?._triggerAttributeRefresh(true);
     }
 
     private _computeCanClear(value: string, readOnly: boolean): boolean {


### PR DESCRIPTION
When clearing an attribute of type BinaryFile (and it is se to trigger a refresh) the trigger refresh logic will be called

Closes #32