### PR TITLE
feat: Add PersistentObjectAttributeTime component

### DIFF
--- a/packages/vidyano/src/web-components/persistent-object-attribute-presenter/persistent-object-attribute-presenter.ts
+++ b/packages/vidyano/src/web-components/persistent-object-attribute-presenter/persistent-object-attribute-presenter.ts
@@ -24,6 +24,7 @@ import "components/persistent-object-attribute/attributes/persistent-object-attr
 import "components/persistent-object-attribute/attributes/persistent-object-attribute-password/persistent-object-attribute-password"
 import "components/persistent-object-attribute/attributes/persistent-object-attribute-reference/persistent-object-attribute-reference"
 import { PersistentObjectAttributeString } from "components/persistent-object-attribute/attributes/persistent-object-attribute-string/persistent-object-attribute-string"
+import "components/persistent-object-attribute/attributes/persistent-object-attribute-time/persistent-object-attribute-time"
 import "components/persistent-object-attribute/attributes/persistent-object-attribute-translated-string/persistent-object-attribute-translated-string"
 import "components/persistent-object-attribute/attributes/persistent-object-attribute-user/persistent-object-attribute-user"
 import "components/persistent-object-attribute-label/persistent-object-attribute-label"

--- a/packages/vidyano/src/web-components/persistent-object-attribute/attributes/persistent-object-attribute-time/persistent-object-attribute-time.scss
+++ b/packages/vidyano/src/web-components/persistent-object-attribute/attributes/persistent-object-attribute-time/persistent-object-attribute-time.scss
@@ -1,0 +1,32 @@
+:host {
+    display: flex;
+
+    &[editing] {
+        [slot="content"] {
+            display: flex;
+        }
+
+        vi-masked-input {
+            display: inline-block;
+            border: none;
+            height: calc(var(--theme-h2) - 2px);
+            line-height: calc(var(--theme-h2) - 2px);
+            flex: 1;
+            min-height: 0;
+            min-width: 0;
+        }
+
+        vi-masked-input[invalid]::part(input) {
+            color: red;
+        }
+    }
+
+    span, vi-masked-input {
+        color: var(--vi-persistent-object-attribute-foreground, var(--theme-foreground));
+    }
+
+    vi-time-picker::part(icon) {
+        width: calc(var(--theme-h2) - 2px);
+        height: calc(var(--theme-h2) - 2px);
+    }
+}

--- a/packages/vidyano/src/web-components/persistent-object-attribute/attributes/persistent-object-attribute-time/persistent-object-attribute-time.ts
+++ b/packages/vidyano/src/web-components/persistent-object-attribute/attributes/persistent-object-attribute-time/persistent-object-attribute-time.ts
@@ -95,19 +95,17 @@ export class PersistentObjectAttributeTime extends PersistentObjectAttribute {
         if (typeof value !== "string" || value.length === 0)
             return null;
 
-        // Parse .NET TimeSpan string format: "d:HH:MM:SS.fffffff" (e.g., "0:14:30:00.0000000")
-        const parts = value.split(/[:.]/);
-        if (parts.length < 4)
+        // Parse .NET TimeSpan string format: [d. or d:]HH:mm:ss[.fffffff]
+        const match = /^(?:(\d+)[.:])?(\d{1,2}):(\d{1,2}):(\d{1,2})(?:\.(\d+))?$/.exec(value);
+        if (!match)
             return null;
 
-        const startIndex = parts.length - 4;
-        const hours = parseInt(parts[startIndex], 10);
-        const minutes = parseInt(parts[startIndex + 1], 10);
-        const seconds = parseInt(parts[startIndex + 2], 10);
-        const milliseconds = parseInt(parts[startIndex + 3].substring(0, 3), 10);
-
-        if ([hours, minutes, seconds, milliseconds].some(Number.isNaN))
-            return null;
+        const hours = parseInt(match[2], 10);
+        const minutes = parseInt(match[3], 10);
+        const seconds = parseInt(match[4], 10);
+        let milliseconds = 0;
+        if (match[5])
+            milliseconds = parseInt(match[5].substring(0, 3).padEnd(3, "0"), 10);
 
         const time = new Date();
         time.setHours(hours, minutes, seconds, milliseconds);

--- a/packages/vidyano/src/web-components/persistent-object-attribute/attributes/persistent-object-attribute-time/persistent-object-attribute-time.ts
+++ b/packages/vidyano/src/web-components/persistent-object-attribute/attributes/persistent-object-attribute-time/persistent-object-attribute-time.ts
@@ -1,0 +1,228 @@
+import { html, nothing, unsafeCSS, type TemplateResult } from "lit";
+import { query, state } from "lit/decorators.js";
+import * as Vidyano from "@vidyano/core";
+import "components/masked-input/masked-input";
+import { computed } from "components/web-component/web-component";
+import { PersistentObjectAttribute } from "components/persistent-object-attribute/persistent-object-attribute";
+import * as PersistentObjectAttributeRegister from "components/persistent-object-attribute/persistent-object-attribute-register";
+import type { TimePicker } from "../../../time-picker/time-picker.js";
+import "../../../time-picker/time-picker.js";
+import type { MaskedInput } from "../../../masked-input/masked-input.js";
+import styles from "./persistent-object-attribute-time.css";
+
+export class PersistentObjectAttributeTime extends PersistentObjectAttribute {
+    static styles = [super.styles, unsafeCSS(styles)];
+
+    @state()
+    selectedTime: Date;
+
+    @state()
+    private _timeInvalid: boolean = false;
+
+    get #culture(): Vidyano.CultureInfo {
+        return Vidyano.CultureInfo.currentCulture || Vidyano.CultureInfo.invariantCulture;
+    }
+
+    get timeFormat(): string {
+        return "__" + this.#culture.dateFormat.timeSeparator + "__";
+    }
+
+    get timeSeparator(): string {
+        return this.#culture.dateFormat.timeSeparator;
+    }
+
+    get #timeDisplayValue(): string {
+        if (this.selectedTime)
+            return String.format(`{0:D2}${this.timeSeparator}{1:D2}`, this.selectedTime.getHours(), this.selectedTime.getMinutes());
+
+        return this.readOnly ? "—" : this.timeFormat;
+    }
+
+    @computed(function(this: PersistentObjectAttributeTime): boolean {
+        return this.attribute?.value != null && !this.attribute?.isRequired;
+    }, "attribute.value", "attribute.isRequired")
+    declare readonly canClear: boolean;
+
+    @query("vi-masked-input")
+    private declare readonly timeInput: MaskedInput;
+
+    @query("#timepicker")
+    private declare readonly timePicker: TimePicker;
+
+    override focus() {
+        this.timeInput?.focus();
+    }
+
+    protected override _editingChanged() {
+        super._editingChanged();
+
+        if (this.editing)
+            this._timeInvalid = false;
+    }
+
+    protected override _valueChanged(value: Date | string, oldValue: any) {
+        super._valueChanged(value, oldValue);
+
+        const parsed = this.#parseTime(value);
+        if (this.#sameHM(this.selectedTime, parsed))
+            return;
+
+        this.selectedTime = parsed;
+        if (!this.editing)
+            this._timeInvalid = false;
+    }
+
+    #sameHM(a: Date | null, b: Date | null): boolean {
+        if (a == null && b == null)
+            return true;
+
+        if (a == null || b == null)
+            return false;
+
+        return a.getHours() === b.getHours() && a.getMinutes() === b.getMinutes();
+    }
+
+    #parseTime(value: Date | string | null): Date | null {
+        if (value == null)
+            return null;
+
+        if (value instanceof Date) {
+            const time = new Date();
+            time.setHours(value.getHours(), value.getMinutes(), value.getSeconds(), value.getMilliseconds());
+            return time;
+        }
+
+        if (typeof value !== "string" || value.length === 0)
+            return null;
+
+        // Parse .NET TimeSpan string format: "d:HH:MM:SS.fffffff" (e.g., "0:14:30:00.0000000")
+        const parts = value.split(/[:.]/);
+        if (parts.length < 4)
+            return null;
+
+        const startIndex = parts.length - 4;
+        const hours = parseInt(parts[startIndex], 10);
+        const minutes = parseInt(parts[startIndex + 1], 10);
+        const seconds = parseInt(parts[startIndex + 2], 10);
+        const milliseconds = parseInt(parts[startIndex + 3].substring(0, 3), 10);
+
+        if ([hours, minutes, seconds, milliseconds].some(Number.isNaN))
+            return null;
+
+        const time = new Date();
+        time.setHours(hours, minutes, seconds, milliseconds);
+        return time;
+    }
+
+    #toServiceValue(time: Date | null): string | null {
+        if (!time)
+            return null;
+
+        return String.format("0:{0:D2}:{1:D2}:{2:D2}.{3:D3}0000", time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
+    }
+
+    #updateAttributeValue(time: Date | null) {
+        const serviceValue = this.#toServiceValue(time);
+        if (serviceValue === this.value)
+            return;
+
+        this._timeInvalid = false;
+        this.attribute.setValue(serviceValue, true).catch(Vidyano.noop);
+    }
+
+    private _timeChanged(e: CustomEvent) {
+        const newTime = e.detail.value as Date | null;
+        if (this.#sameHM(this.selectedTime, newTime))
+            return;
+
+        if (!newTime)
+            return;
+
+        const normalized = new Date();
+        normalized.setHours(newTime.getHours(), newTime.getMinutes(), 0, 0);
+
+        this.selectedTime = normalized;
+        this.#updateAttributeValue(normalized);
+    }
+
+    private _timeFilled() {
+        if (!this.timeInput)
+            return;
+
+        const timeParts = this.timeInput.value.split(this.timeSeparator);
+        if (timeParts.length === 2) {
+            const hours = parseInt(timeParts[0], 10);
+            const minutes = parseInt(timeParts[1], 10);
+
+            if (!isNaN(hours) && hours >= 0 && hours <= 23 && !isNaN(minutes) && minutes >= 0 && minutes <= 59) {
+                const newTime = new Date();
+                newTime.setHours(hours, minutes, 0, 0);
+
+                this._timeInvalid = false;
+
+                if (this.#sameHM(this.selectedTime, newTime))
+                    return;
+
+                this.selectedTime = newTime;
+                this.#updateAttributeValue(newTime);
+                return;
+            }
+        }
+
+        this._timeInvalid = true;
+    }
+
+    private _focusout(e: FocusEvent) {
+        if (!this.editing || this.readOnly)
+            return;
+
+        const related = e.relatedTarget as Node;
+        if (related && (this.timePicker?.contains(related) || related === this.timeInput))
+            return;
+
+        const value = this.timeInput?.value;
+        if ((value === this.timeFormat || value === "") && !this.attribute.isRequired)
+            this._timeInvalid = false;
+    }
+
+    private _clear() {
+        this.attribute.setValue(null, true).catch(Vidyano.noop);
+    }
+
+    protected override renderDisplay() {
+        return super.renderDisplay(html`<span>${this.attribute?.displayValue}</span>`);
+    }
+
+    protected override renderEdit(innerTemplate?: TemplateResult) {
+        return super.renderEdit(html`
+            <vi-sensitive ?disabled=${!this.sensitive}>
+                <vi-masked-input
+                    .format=${this.timeFormat}
+                    .separator=${this.timeSeparator}
+                    .value=${this.#timeDisplayValue}
+                    ?disabled=${this.readOnly || this.frozen}
+                    ?invalid=${this._timeInvalid}
+                    tabindex=${this.readOnlyTabIndex || nothing}
+                    @filled=${this._timeFilled}
+                    @focusout=${this._focusout}>
+                </vi-masked-input>
+            </vi-sensitive>
+            ${!this.readOnly ? html`
+                <vi-time-picker slot="right" id="timepicker"
+                    .time=${this.selectedTime}
+                    @time-changed=${this._timeChanged}>
+                </vi-time-picker>
+                ${this.canClear ? html`
+                    <vi-button id="clearButton" slot="right" @click=${this._clear} tabindex="-1" ?disabled=${this.frozen}>
+                        <vi-icon source="Remove"></vi-icon>
+                    </vi-button>
+                ` : nothing}
+            ` : nothing}
+        `);
+    }
+}
+
+customElements.define("vi-persistent-object-attribute-time", PersistentObjectAttributeTime);
+
+PersistentObjectAttributeRegister.add("Time", PersistentObjectAttributeTime);
+PersistentObjectAttributeRegister.add("NullableTime", PersistentObjectAttributeTime);


### PR DESCRIPTION
## Summary

Vidyano has no default renderer registered for `Time` / `NullableTime` attributes, so values fall back to `PersistentObjectAttributeString` and display the raw .NET `TimeSpan` string (e.g. `0:14:30:00.0000000`). This PR adds a dedicated renderer that shows `HH:MM` with the built-in `vi-time-picker` clock popup and writes values back as `TimeSpan`.

## Changes

- **New component** `persistent-object-attribute-time` under `packages/vidyano/src/web-components/persistent-object-attribute/attributes/`, following the same conventions as the other attribute renderers (e.g. `persistent-object-attribute-date-time`):
  - Uses `@state`, `@query`, `@computed` decorators
  - Locale-aware time separator via `Vidyano.CultureInfo`
  - Parses the `.NET` `TimeSpan` format `d:HH:MM:SS.fffffff` and emits `0:HH:MM:SS.fff0000`
  - `vi-masked-input` + `vi-time-picker` + clear button, mirroring the time-only path of the date-time renderer
- Registers `PersistentObjectAttributeTime` for `Time` and `NullableTime`
- Adds the import to `persistent-object-attribute-presenter.ts`

## Test plan

- [ ] Verify `Time` attribute renders `HH:MM` in non-edit mode (not the raw TimeSpan string)
- [ ] Verify edit mode shows masked input + time picker
- [ ] Verify picker selection persists on save (round-trip through the .NET `TimeSpan` serialization)
- [ ] Verify typing `HH:MM` directly into the masked input saves correctly
- [ ] Verify clear button works for `NullableTime` (hidden for required `Time`)
- [ ] Verify read-only mode shows the value without input / picker

## Notes

- `npm run build` succeeds locally and the component bundles into `dev/wwwroot/index.js`.
- The existing `PersistentObjectAttributeDateTime` contained an internal branch for `Time` / `NullableTime` (lines 161-162, 237-246) that was never reachable because those types were not registered. I left that code untouched to keep this PR scoped; happy to add a cleanup commit if maintainers prefer.
- Tests (`.spec.ts` + `.cs` mock) can be added in a follow-up if you'd like coverage parity with the other attribute components — let me know your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)